### PR TITLE
Fix/firmware disconnect failsafe

### DIFF
--- a/pio_workspace/src/power_main.cpp
+++ b/pio_workspace/src/power_main.cpp
@@ -167,12 +167,12 @@ void destroy_entities() {
   disconnectUSB();
   delay(25);
   
+  updateThrusters(offCommand);
+  
   // Clear out the global array so old commands aren't cached
   for(int i = 0; i < 8; i++) {
     microseconds[i] = 1500;
-  }
-  
-  updateThrusters(offCommand);
+  }  
 
   rmw_context_t * rmw_context = rcl_context_get_rmw_context(&support.context);
   (void) rmw_uros_set_context_entity_destroy_session_timeout(rmw_context, 0);
@@ -269,19 +269,13 @@ void power_setup() {
 void power_loop() {
   senseData();
 
-  // SAFETY FAILSAFE: Only apply ROS thruster commands if connected.
-  if (state == AGENT_CONNECTED) {
-    updateThrusters(microseconds);
-  } else {
-    // If we lose connection to Jetson/ROS, immediately stop thrusters.
-    updateThrusters(offCommand);
-  }
-
   switch (state) {
     case WAITING_AGENT:
+      updateThrusters(offCommand);
       EXECUTE_EVERY_N_MS(500, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_AVAILABLE : WAITING_AGENT;);
       break;
     case AGENT_AVAILABLE:
+      updateThrusters(offCommand);
       state = (true == create_entities()) ? AGENT_CONNECTED : WAITING_AGENT;
       if (state == WAITING_AGENT) {
         destroy_entities();
@@ -291,6 +285,7 @@ void power_loop() {
       EXECUTE_EVERY_N_MS(200, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_CONNECTED : AGENT_DISCONNECTED;);
       if (state == AGENT_CONNECTED) {
         rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100));
+        updateThrusters(microseconds);
       }
       break;
     case AGENT_DISCONNECTED:

--- a/pio_workspace/src/power_main.cpp
+++ b/pio_workspace/src/power_main.cpp
@@ -167,12 +167,10 @@ void destroy_entities() {
   disconnectUSB();
   delay(25);
   
-  updateThrusters(offCommand);
-  
   // Clear out the global array so old commands aren't cached
   for(int i = 0; i < 8; i++) {
     microseconds[i] = 1500;
-  }  
+  }
 
   rmw_context_t * rmw_context = rcl_context_get_rmw_context(&support.context);
   (void) rmw_uros_set_context_entity_destroy_session_timeout(rmw_context, 0);
@@ -282,10 +280,12 @@ void power_loop() {
       };
       break;
     case AGENT_CONNECTED:
-      EXECUTE_EVERY_N_MS(200, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_CONNECTED : AGENT_DISCONNECTED;);
+      EXECUTE_EVERY_N_MS(50, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_CONNECTED : AGENT_DISCONNECTED;);
       if (state == AGENT_CONNECTED) {
         rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100));
         updateThrusters(microseconds);
+      } else {
+        updateThrusters(offCommand);
       }
       break;
     case AGENT_DISCONNECTED:

--- a/pio_workspace/src/power_main.cpp
+++ b/pio_workspace/src/power_main.cpp
@@ -4,25 +4,24 @@
 
 #include <Arduino.h>
 
+#include "TMP36.h"
 #include "ThrusterControl.h"
 #include "adc_sensors.h"
-#include "TMP36.h"
 
 #include <micro_ros_arduino.h>
 
-#include <stdio.h>
-#include <rcl/rcl.h>
 #include <rcl/error_handling.h>
-#include <rclc/rclc.h>
+#include <rcl/rcl.h>
 #include <rclc/executor.h>
+#include <rclc/rclc.h>
 #include <rmw_microros/rmw_microros.h>
+#include <stdio.h>
 
-#include <std_msgs/msg/int16_multi_array.h>
 #include <std_msgs/msg/float32.h>
 #include <std_msgs/msg/float32_multi_array.h>
+#include <std_msgs/msg/int16_multi_array.h>
 
 #define LED_PIN 13
-
 
 #define ENABLE_VOLTAGE_SENSE true
 #define ENABLE_CURRENT_SENSE true
@@ -53,23 +52,40 @@ rcl_allocator_t allocator;
 rcl_node_t node;
 rcl_timer_t timer;
 
-#define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){error_loop();}}
-#define RCSOFTCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){}}
+#define RCCHECK(fn)                                                            \
+  {                                                                            \
+    rcl_ret_t temp_rc = fn;                                                    \
+    if ((temp_rc != RCL_RET_OK)) {                                             \
+      error_loop();                                                            \
+    }                                                                          \
+  }
+#define RCSOFTCHECK(fn)                                                        \
+  {                                                                            \
+    rcl_ret_t temp_rc = fn;                                                    \
+    if ((temp_rc != RCL_RET_OK)) {                                             \
+    }                                                                          \
+  }
 
-#define EXECUTE_EVERY_N_MS(MS, X)  do { \
-  static volatile int64_t init = -1; \
-  if (init == -1) { init = uxr_millis();} \
-  if (uxr_millis() - init > MS) { X; init = uxr_millis();} \
-} while (0)\
+#define EXECUTE_EVERY_N_MS(MS, X)                                              \
+  do {                                                                         \
+    static volatile int64_t init = -1;                                         \
+    if (init == -1) {                                                          \
+      init = uxr_millis();                                                     \
+    }                                                                          \
+    if (uxr_millis() - init > MS) {                                            \
+      X;                                                                       \
+      init = uxr_millis();                                                     \
+    }                                                                          \
+  } while (0)
 
 void error_loop() {
-    int error = 0;
-    while (error < 10) {
-        digitalWrite(LED_PIN, !digitalRead(LED_PIN));
-        delay(100);
-        error++;
-    }
-    digitalWrite(LED_PIN, HIGH);
+  int error = 0;
+  while (error < 10) {
+    digitalWrite(LED_PIN, !digitalRead(LED_PIN));
+    delay(100);
+    error++;
+  }
+  digitalWrite(LED_PIN, HIGH);
 }
 
 enum states {
@@ -79,22 +95,26 @@ enum states {
   AGENT_DISCONNECTED
 } state;
 
-void propulsion_microseconds_callback(const void * msgin)
-{  
-  const std_msgs__msg__Int16MultiArray * msg = (const std_msgs__msg__Int16MultiArray *)msgin;
+void propulsion_microseconds_callback(const void *msgin) {
+  const std_msgs__msg__Int16MultiArray *msg =
+      (const std_msgs__msg__Int16MultiArray *)msgin;
 
   for (int i = 0; i < 8; i++) {
     microseconds[i] = msg->data.data[i];
   }
 }
 
-void timer_callback(rcl_timer_t * timer, int64_t last_call_time) {
+void timer_callback(rcl_timer_t *timer, int64_t last_call_time) {
   RCLC_UNUSED(last_call_time);
   if (timer != NULL) {
-    RCSOFTCHECK(rcl_publish(&power_batteries_voltage_publisher, &power_batteries_voltage_msg, NULL));
-    RCSOFTCHECK(rcl_publish(&power_thrusters_current_publisher, &power_thrusters_current_msg, NULL));
-    RCSOFTCHECK(rcl_publish(&power_board_temperature_publisher, &power_board_temperature_msg, NULL));
-    RCSOFTCHECK(rcl_publish(&power_teensy_temperature_publisher, &power_teensy_temperature_msg, NULL));
+    RCSOFTCHECK(rcl_publish(&power_batteries_voltage_publisher,
+                            &power_batteries_voltage_msg, NULL));
+    RCSOFTCHECK(rcl_publish(&power_thrusters_current_publisher,
+                            &power_thrusters_current_msg, NULL));
+    RCSOFTCHECK(rcl_publish(&power_board_temperature_publisher,
+                            &power_board_temperature_msg, NULL));
+    RCSOFTCHECK(rcl_publish(&power_teensy_temperature_publisher,
+                            &power_teensy_temperature_msg, NULL));
   }
 }
 
@@ -108,74 +128,67 @@ bool create_entities() {
   RCCHECK(rclc_node_init_default(&node, "power_node", "", &support));
 
   RCCHECK(rclc_subscription_init_default(
-    &propulsion_microseconds_subscriber,
-    &node,
-    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int16MultiArray),
-    "/propulsion/microseconds"));
+      &propulsion_microseconds_subscriber, &node,
+      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int16MultiArray),
+      "/propulsion/microseconds"));
 
   /// create publisher
   RCCHECK(rclc_publisher_init_default(
-    &power_batteries_voltage_publisher,
-    &node,
-    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray),
-    "/power/batteries/voltage"));
+      &power_batteries_voltage_publisher, &node,
+      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray),
+      "/power/batteries/voltage"));
 
   RCCHECK(rclc_publisher_init_default(
-    &power_thrusters_current_publisher,
-    &node,
-    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray),
-    "/power/thrusters/current"));
-  
-  RCCHECK(rclc_publisher_init_default(
-    &power_board_temperature_publisher,
-    &node,
-    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32),
-    "/power/board/temperature"));
+      &power_thrusters_current_publisher, &node,
+      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray),
+      "/power/thrusters/current"));
 
   RCCHECK(rclc_publisher_init_default(
-    &power_teensy_temperature_publisher,
-    &node,
-    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32),
-    "/power/teensy/temperature"));
+      &power_board_temperature_publisher, &node,
+      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32),
+      "/power/board/temperature"));
+
+  RCCHECK(rclc_publisher_init_default(
+      &power_teensy_temperature_publisher, &node,
+      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32),
+      "/power/teensy/temperature"));
 
   // create timer,
   const unsigned int timer_timeout = 1000;
-  RCCHECK(rclc_timer_init_default(
-    &timer,
-    &support,
-    RCL_MS_TO_NS(timer_timeout),
-    timer_callback));
+  RCCHECK(rclc_timer_init_default(&timer, &support, RCL_MS_TO_NS(timer_timeout),
+                                  timer_callback));
 
   // create executor
   executor = rclc_executor_get_zero_initialized_executor();
-  RCCHECK(rclc_executor_init(&executor, &support.context, 100, &allocator)); // number arbitrarily set, idk what is the correct on yet, trial and error later on
+  RCCHECK(rclc_executor_init(
+      &executor, &support.context, 100,
+      &allocator)); // number arbitrarily set, idk what is the correct on yet,
+                    // trial and error later on
   RCCHECK(rclc_executor_add_timer(&executor, &timer));
-  RCCHECK(rclc_executor_add_subscription(&executor, &propulsion_microseconds_subscriber, &propulsion_microseconds_msg, &propulsion_microseconds_callback, ON_NEW_DATA));
-
+  RCCHECK(rclc_executor_add_subscription(
+      &executor, &propulsion_microseconds_subscriber,
+      &propulsion_microseconds_msg, &propulsion_microseconds_callback,
+      ON_NEW_DATA));
 
   return true;
 }
 
-void disconnectUSB() {
-  USB1_USBCMD = 0;
-}
-void connectUSB() {
-  USB1_USBCMD = 1;
-}
+void disconnectUSB() { USB1_USBCMD = 0; }
+void connectUSB() { USB1_USBCMD = 1; }
 
 void destroy_entities() {
   disconnectUSB();
   delay(25);
-  
+
   // Clear out the global array so old commands aren't cached
-  for(int i = 0; i < 8; i++) {
+  for (int i = 0; i < 8; i++) {
     microseconds[i] = 1500;
   }
-  
+
   updateThrusters(offCommand);
 
-  rmw_context_t * rmw_context = rcl_context_get_rmw_context(&support.context);
-  (void) rmw_uros_set_context_entity_destroy_session_timeout(rmw_context, 0);
+  rmw_context_t *rmw_context = rcl_context_get_rmw_context(&support.context);
+  (void)rmw_uros_set_context_entity_destroy_session_timeout(rmw_context, 0);
 
   rcl_publisher_fini(&power_batteries_voltage_publisher, &node);
   rcl_publisher_fini(&power_thrusters_current_publisher, &node);
@@ -196,14 +209,14 @@ void senseData() {
 
   power_teensy_temperature_msg.data = tempmonGetTemp();
 
-  float* current_data = adcSensors.senseCurrent();
+  float *current_data = adcSensors.senseCurrent();
   for (size_t i = 0; i < 8; i++) {
-      power_thrusters_current_msg.data.data[i] = current_data[i];
+    power_thrusters_current_msg.data.data[i] = current_data[i];
   }
 
-  float* voltage_data = adcSensors.senseVoltage();
+  float *voltage_data = adcSensors.senseVoltage();
   for (size_t i = 0; i < 2; i++) {
-      power_batteries_voltage_msg.data.data[i] = voltage_data[i];
+    power_batteries_voltage_msg.data.data[i] = voltage_data[i];
   }
 }
 
@@ -225,21 +238,24 @@ void power_setup() {
 
   propulsion_microseconds_msg.data.size = 8;
   propulsion_microseconds_msg.data.capacity = 8;
-  propulsion_microseconds_msg.data.data = (int16_t*)malloc(propulsion_microseconds_msg.data.capacity * sizeof(int16_t));
+  propulsion_microseconds_msg.data.data = (int16_t *)malloc(
+      propulsion_microseconds_msg.data.capacity * sizeof(int16_t));
   for (int i = 0; i < 8; i++) {
     propulsion_microseconds_msg.data.data[i] = 0;
   }
 
   power_batteries_voltage_msg.data.size = 2;
   power_batteries_voltage_msg.data.capacity = 2;
-  power_batteries_voltage_msg.data.data = (float*)malloc(power_batteries_voltage_msg.data.capacity * sizeof(float));
+  power_batteries_voltage_msg.data.data = (float *)malloc(
+      power_batteries_voltage_msg.data.capacity * sizeof(float));
   for (int i = 0; i < 2; i++) {
     power_batteries_voltage_msg.data.data[i] = 0.0;
   }
 
   power_thrusters_current_msg.data.size = 8;
   power_thrusters_current_msg.data.capacity = 8;
-  power_thrusters_current_msg.data.data = (float*)malloc(power_thrusters_current_msg.data.capacity * sizeof(float));
+  power_thrusters_current_msg.data.data = (float *)malloc(
+      power_thrusters_current_msg.data.capacity * sizeof(float));
   for (int i = 0; i < 8; i++) {
     power_thrusters_current_msg.data.data[i] = 0.0;
   }
@@ -248,7 +264,8 @@ void power_setup() {
 
   power_teensy_temperature_msg.data = 0.0;
 
-  //allocates thrusters to 1500 in case of reset and allocates -2.0 to sensing to go under the -1.0 of unintiailized from drivers
+  // allocates thrusters to 1500 in case of reset and allocates -2.0 to sensing
+  // to go under the -1.0 of unintiailized from drivers
 
   for (int i = 0; i < 8; i++) {
     propulsion_microseconds_msg.data.data[i] = 1500;
@@ -278,27 +295,31 @@ void power_loop() {
   }
 
   switch (state) {
-    case WAITING_AGENT:
-      EXECUTE_EVERY_N_MS(500, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_AVAILABLE : WAITING_AGENT;);
-      break;
-    case AGENT_AVAILABLE:
-      state = (true == create_entities()) ? AGENT_CONNECTED : WAITING_AGENT;
-      if (state == WAITING_AGENT) {
-        destroy_entities();
-      };
-      break;
-    case AGENT_CONNECTED:
-      EXECUTE_EVERY_N_MS(200, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_CONNECTED : AGENT_DISCONNECTED;);
-      if (state == AGENT_CONNECTED) {
-        rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100));
-      }
-      break;
-    case AGENT_DISCONNECTED:
+  case WAITING_AGENT:
+    EXECUTE_EVERY_N_MS(500, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1))
+                                        ? AGENT_AVAILABLE
+                                        : WAITING_AGENT;);
+    break;
+  case AGENT_AVAILABLE:
+    state = (true == create_entities()) ? AGENT_CONNECTED : WAITING_AGENT;
+    if (state == WAITING_AGENT) {
       destroy_entities();
-      state = WAITING_AGENT;
-      break;
-    default:
-      break;
+    };
+    break;
+  case AGENT_CONNECTED:
+    EXECUTE_EVERY_N_MS(200, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1))
+                                        ? AGENT_CONNECTED
+                                        : AGENT_DISCONNECTED;);
+    if (state == AGENT_CONNECTED) {
+      rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100));
+    }
+    break;
+  case AGENT_DISCONNECTED:
+    destroy_entities();
+    state = WAITING_AGENT;
+    break;
+  default:
+    break;
   }
 
   if (state == AGENT_CONNECTED) {

--- a/pio_workspace/src/power_main.cpp
+++ b/pio_workspace/src/power_main.cpp
@@ -4,24 +4,25 @@
 
 #include <Arduino.h>
 
-#include "TMP36.h"
 #include "ThrusterControl.h"
 #include "adc_sensors.h"
+#include "TMP36.h"
 
 #include <micro_ros_arduino.h>
 
-#include <rcl/error_handling.h>
-#include <rcl/rcl.h>
-#include <rclc/executor.h>
-#include <rclc/rclc.h>
-#include <rmw_microros/rmw_microros.h>
 #include <stdio.h>
+#include <rcl/rcl.h>
+#include <rcl/error_handling.h>
+#include <rclc/rclc.h>
+#include <rclc/executor.h>
+#include <rmw_microros/rmw_microros.h>
 
+#include <std_msgs/msg/int16_multi_array.h>
 #include <std_msgs/msg/float32.h>
 #include <std_msgs/msg/float32_multi_array.h>
-#include <std_msgs/msg/int16_multi_array.h>
 
 #define LED_PIN 13
+
 
 #define ENABLE_VOLTAGE_SENSE true
 #define ENABLE_CURRENT_SENSE true
@@ -52,40 +53,23 @@ rcl_allocator_t allocator;
 rcl_node_t node;
 rcl_timer_t timer;
 
-#define RCCHECK(fn)                                                            \
-  {                                                                            \
-    rcl_ret_t temp_rc = fn;                                                    \
-    if ((temp_rc != RCL_RET_OK)) {                                             \
-      error_loop();                                                            \
-    }                                                                          \
-  }
-#define RCSOFTCHECK(fn)                                                        \
-  {                                                                            \
-    rcl_ret_t temp_rc = fn;                                                    \
-    if ((temp_rc != RCL_RET_OK)) {                                             \
-    }                                                                          \
-  }
+#define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){error_loop();}}
+#define RCSOFTCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){}}
 
-#define EXECUTE_EVERY_N_MS(MS, X)                                              \
-  do {                                                                         \
-    static volatile int64_t init = -1;                                         \
-    if (init == -1) {                                                          \
-      init = uxr_millis();                                                     \
-    }                                                                          \
-    if (uxr_millis() - init > MS) {                                            \
-      X;                                                                       \
-      init = uxr_millis();                                                     \
-    }                                                                          \
-  } while (0)
+#define EXECUTE_EVERY_N_MS(MS, X)  do { \
+  static volatile int64_t init = -1; \
+  if (init == -1) { init = uxr_millis();} \
+  if (uxr_millis() - init > MS) { X; init = uxr_millis();} \
+} while (0)\
 
 void error_loop() {
-  int error = 0;
-  while (error < 10) {
-    digitalWrite(LED_PIN, !digitalRead(LED_PIN));
-    delay(100);
-    error++;
-  }
-  digitalWrite(LED_PIN, HIGH);
+    int error = 0;
+    while (error < 10) {
+        digitalWrite(LED_PIN, !digitalRead(LED_PIN));
+        delay(100);
+        error++;
+    }
+    digitalWrite(LED_PIN, HIGH);
 }
 
 enum states {
@@ -95,26 +79,22 @@ enum states {
   AGENT_DISCONNECTED
 } state;
 
-void propulsion_microseconds_callback(const void *msgin) {
-  const std_msgs__msg__Int16MultiArray *msg =
-      (const std_msgs__msg__Int16MultiArray *)msgin;
+void propulsion_microseconds_callback(const void * msgin)
+{  
+  const std_msgs__msg__Int16MultiArray * msg = (const std_msgs__msg__Int16MultiArray *)msgin;
 
   for (int i = 0; i < 8; i++) {
     microseconds[i] = msg->data.data[i];
   }
 }
 
-void timer_callback(rcl_timer_t *timer, int64_t last_call_time) {
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time) {
   RCLC_UNUSED(last_call_time);
   if (timer != NULL) {
-    RCSOFTCHECK(rcl_publish(&power_batteries_voltage_publisher,
-                            &power_batteries_voltage_msg, NULL));
-    RCSOFTCHECK(rcl_publish(&power_thrusters_current_publisher,
-                            &power_thrusters_current_msg, NULL));
-    RCSOFTCHECK(rcl_publish(&power_board_temperature_publisher,
-                            &power_board_temperature_msg, NULL));
-    RCSOFTCHECK(rcl_publish(&power_teensy_temperature_publisher,
-                            &power_teensy_temperature_msg, NULL));
+    RCSOFTCHECK(rcl_publish(&power_batteries_voltage_publisher, &power_batteries_voltage_msg, NULL));
+    RCSOFTCHECK(rcl_publish(&power_thrusters_current_publisher, &power_thrusters_current_msg, NULL));
+    RCSOFTCHECK(rcl_publish(&power_board_temperature_publisher, &power_board_temperature_msg, NULL));
+    RCSOFTCHECK(rcl_publish(&power_teensy_temperature_publisher, &power_teensy_temperature_msg, NULL));
   }
 }
 
@@ -128,67 +108,74 @@ bool create_entities() {
   RCCHECK(rclc_node_init_default(&node, "power_node", "", &support));
 
   RCCHECK(rclc_subscription_init_default(
-      &propulsion_microseconds_subscriber, &node,
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int16MultiArray),
-      "/propulsion/microseconds"));
+    &propulsion_microseconds_subscriber,
+    &node,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int16MultiArray),
+    "/propulsion/microseconds"));
 
   /// create publisher
   RCCHECK(rclc_publisher_init_default(
-      &power_batteries_voltage_publisher, &node,
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray),
-      "/power/batteries/voltage"));
+    &power_batteries_voltage_publisher,
+    &node,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray),
+    "/power/batteries/voltage"));
 
   RCCHECK(rclc_publisher_init_default(
-      &power_thrusters_current_publisher, &node,
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray),
-      "/power/thrusters/current"));
+    &power_thrusters_current_publisher,
+    &node,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray),
+    "/power/thrusters/current"));
+  
+  RCCHECK(rclc_publisher_init_default(
+    &power_board_temperature_publisher,
+    &node,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32),
+    "/power/board/temperature"));
 
   RCCHECK(rclc_publisher_init_default(
-      &power_board_temperature_publisher, &node,
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32),
-      "/power/board/temperature"));
-
-  RCCHECK(rclc_publisher_init_default(
-      &power_teensy_temperature_publisher, &node,
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32),
-      "/power/teensy/temperature"));
+    &power_teensy_temperature_publisher,
+    &node,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32),
+    "/power/teensy/temperature"));
 
   // create timer,
   const unsigned int timer_timeout = 1000;
-  RCCHECK(rclc_timer_init_default(&timer, &support, RCL_MS_TO_NS(timer_timeout),
-                                  timer_callback));
+  RCCHECK(rclc_timer_init_default(
+    &timer,
+    &support,
+    RCL_MS_TO_NS(timer_timeout),
+    timer_callback));
 
   // create executor
   executor = rclc_executor_get_zero_initialized_executor();
-  RCCHECK(rclc_executor_init(
-      &executor, &support.context, 100,
-      &allocator)); // number arbitrarily set, idk what is the correct on yet,
-                    // trial and error later on
+  RCCHECK(rclc_executor_init(&executor, &support.context, 100, &allocator)); // number arbitrarily set, idk what is the correct on yet, trial and error later on
   RCCHECK(rclc_executor_add_timer(&executor, &timer));
-  RCCHECK(rclc_executor_add_subscription(
-      &executor, &propulsion_microseconds_subscriber,
-      &propulsion_microseconds_msg, &propulsion_microseconds_callback,
-      ON_NEW_DATA));
+  RCCHECK(rclc_executor_add_subscription(&executor, &propulsion_microseconds_subscriber, &propulsion_microseconds_msg, &propulsion_microseconds_callback, ON_NEW_DATA));
+
 
   return true;
 }
 
-void disconnectUSB() { USB1_USBCMD = 0; }
-void connectUSB() { USB1_USBCMD = 1; }
+void disconnectUSB() {
+  USB1_USBCMD = 0;
+}
+void connectUSB() {
+  USB1_USBCMD = 1;
+}
 
 void destroy_entities() {
   disconnectUSB();
   delay(25);
-
+  
   // Clear out the global array so old commands aren't cached
-  for (int i = 0; i < 8; i++) {
+  for(int i = 0; i < 8; i++) {
     microseconds[i] = 1500;
   }
-
+  
   updateThrusters(offCommand);
 
-  rmw_context_t *rmw_context = rcl_context_get_rmw_context(&support.context);
-  (void)rmw_uros_set_context_entity_destroy_session_timeout(rmw_context, 0);
+  rmw_context_t * rmw_context = rcl_context_get_rmw_context(&support.context);
+  (void) rmw_uros_set_context_entity_destroy_session_timeout(rmw_context, 0);
 
   rcl_publisher_fini(&power_batteries_voltage_publisher, &node);
   rcl_publisher_fini(&power_thrusters_current_publisher, &node);
@@ -209,14 +196,14 @@ void senseData() {
 
   power_teensy_temperature_msg.data = tempmonGetTemp();
 
-  float *current_data = adcSensors.senseCurrent();
+  float* current_data = adcSensors.senseCurrent();
   for (size_t i = 0; i < 8; i++) {
-    power_thrusters_current_msg.data.data[i] = current_data[i];
+      power_thrusters_current_msg.data.data[i] = current_data[i];
   }
 
-  float *voltage_data = adcSensors.senseVoltage();
+  float* voltage_data = adcSensors.senseVoltage();
   for (size_t i = 0; i < 2; i++) {
-    power_batteries_voltage_msg.data.data[i] = voltage_data[i];
+      power_batteries_voltage_msg.data.data[i] = voltage_data[i];
   }
 }
 
@@ -238,24 +225,21 @@ void power_setup() {
 
   propulsion_microseconds_msg.data.size = 8;
   propulsion_microseconds_msg.data.capacity = 8;
-  propulsion_microseconds_msg.data.data = (int16_t *)malloc(
-      propulsion_microseconds_msg.data.capacity * sizeof(int16_t));
+  propulsion_microseconds_msg.data.data = (int16_t*)malloc(propulsion_microseconds_msg.data.capacity * sizeof(int16_t));
   for (int i = 0; i < 8; i++) {
     propulsion_microseconds_msg.data.data[i] = 0;
   }
 
   power_batteries_voltage_msg.data.size = 2;
   power_batteries_voltage_msg.data.capacity = 2;
-  power_batteries_voltage_msg.data.data = (float *)malloc(
-      power_batteries_voltage_msg.data.capacity * sizeof(float));
+  power_batteries_voltage_msg.data.data = (float*)malloc(power_batteries_voltage_msg.data.capacity * sizeof(float));
   for (int i = 0; i < 2; i++) {
     power_batteries_voltage_msg.data.data[i] = 0.0;
   }
 
   power_thrusters_current_msg.data.size = 8;
   power_thrusters_current_msg.data.capacity = 8;
-  power_thrusters_current_msg.data.data = (float *)malloc(
-      power_thrusters_current_msg.data.capacity * sizeof(float));
+  power_thrusters_current_msg.data.data = (float*)malloc(power_thrusters_current_msg.data.capacity * sizeof(float));
   for (int i = 0; i < 8; i++) {
     power_thrusters_current_msg.data.data[i] = 0.0;
   }
@@ -264,8 +248,7 @@ void power_setup() {
 
   power_teensy_temperature_msg.data = 0.0;
 
-  // allocates thrusters to 1500 in case of reset and allocates -2.0 to sensing
-  // to go under the -1.0 of unintiailized from drivers
+  //allocates thrusters to 1500 in case of reset and allocates -2.0 to sensing to go under the -1.0 of unintiailized from drivers
 
   for (int i = 0; i < 8; i++) {
     propulsion_microseconds_msg.data.data[i] = 1500;
@@ -295,31 +278,27 @@ void power_loop() {
   }
 
   switch (state) {
-  case WAITING_AGENT:
-    EXECUTE_EVERY_N_MS(500, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1))
-                                        ? AGENT_AVAILABLE
-                                        : WAITING_AGENT;);
-    break;
-  case AGENT_AVAILABLE:
-    state = (true == create_entities()) ? AGENT_CONNECTED : WAITING_AGENT;
-    if (state == WAITING_AGENT) {
+    case WAITING_AGENT:
+      EXECUTE_EVERY_N_MS(500, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_AVAILABLE : WAITING_AGENT;);
+      break;
+    case AGENT_AVAILABLE:
+      state = (true == create_entities()) ? AGENT_CONNECTED : WAITING_AGENT;
+      if (state == WAITING_AGENT) {
+        destroy_entities();
+      };
+      break;
+    case AGENT_CONNECTED:
+      EXECUTE_EVERY_N_MS(200, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_CONNECTED : AGENT_DISCONNECTED;);
+      if (state == AGENT_CONNECTED) {
+        rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100));
+      }
+      break;
+    case AGENT_DISCONNECTED:
       destroy_entities();
-    };
-    break;
-  case AGENT_CONNECTED:
-    EXECUTE_EVERY_N_MS(200, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1))
-                                        ? AGENT_CONNECTED
-                                        : AGENT_DISCONNECTED;);
-    if (state == AGENT_CONNECTED) {
-      rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100));
-    }
-    break;
-  case AGENT_DISCONNECTED:
-    destroy_entities();
-    state = WAITING_AGENT;
-    break;
-  default:
-    break;
+      state = WAITING_AGENT;
+      break;
+    default:
+      break;
   }
 
   if (state == AGENT_CONNECTED) {

--- a/pio_workspace/src/power_main.cpp
+++ b/pio_workspace/src/power_main.cpp
@@ -166,6 +166,12 @@ void connectUSB() {
 void destroy_entities() {
   disconnectUSB();
   delay(25);
+  
+  // Clear out the global array so old commands aren't cached
+  for(int i = 0; i < 8; i++) {
+    microseconds[i] = 1500;
+  }
+  
   updateThrusters(offCommand);
 
   rmw_context_t * rmw_context = rcl_context_get_rmw_context(&support.context);
@@ -262,7 +268,14 @@ void power_setup() {
 
 void power_loop() {
   senseData();
-  updateThrusters(microseconds);
+
+  // SAFETY FAILSAFE: Only apply ROS thruster commands if connected.
+  if (state == AGENT_CONNECTED) {
+    updateThrusters(microseconds);
+  } else {
+    // If we lose connection to Jetson/ROS, immediately stop thrusters.
+    updateThrusters(offCommand);
+  }
 
   switch (state) {
     case WAITING_AGENT:


### PR DESCRIPTION
This PR addresses a critical safety bug where the hardware could latch onto the last received thruster command upon losing connection with the micro-ROS agent.

### Changes:
- **`power_loop()` Failsafe**: Now enforces connection state. If `AGENT_CONNECTED` is lost, it immediately triggers `updateThrusters(offCommand)` to stop all motors instead of blindly applying cached values.
- **`destroy_entities()` Cleanup**: Clears the global [microseconds](cci:1://file:///home/sohaib/projects/auv-embedded-2026/pio_workspace/src/power_main.cpp:97:0-104:1) state array to `1500` upon disconnect. This ensures that old "go down" commands aren't erroneously triggered if the ROS agent dynamically reconnects.


**Why this matters:** The firmware is the lowest level of safety. This guarantees that if the Jetson dies or a node crashes, the mechanical output always fails safely.
